### PR TITLE
sync package-lock.json version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-window",
-  "version": "1.0.0",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Also, `memoize-one` is still listed as dependency in your `package-lock.json` without being listed in your `package.json`