### PR TITLE
Fix #7

### DIFF
--- a/src/ListComponent.svelte
+++ b/src/ListComponent.svelte
@@ -198,10 +198,11 @@
     
     const render = () => {
         items = [];
-        items.length = stopIndex - startIndex + 1;
-        const itemKey_ = itemKey || defaultItemKey;
-        
+
         if (itemCount > 0) {
+            items.length = stopIndex - startIndex + 1;
+            const itemKey_ = itemKey || defaultItemKey;
+        
             let i=0;
             for (let index = startIndex; index <= stopIndex; index++) {
                 items[i++] = {


### PR DESCRIPTION
Fix #7 

Hey, took a pretty shallow look at fixing this, seems that on the 0 length case, items would always be initialized with 
```
 items.length = stopIndex  - startIndex + 1; 
// items.length = 0 - 0 + 1; // 0 itemCount now has items.length == 1
```
I figured moving this initialization into the if should be pretty safe here, and it seems to fix the problem on my end.